### PR TITLE
Put dependencies in requirements.txt.

### DIFF
--- a/update-bot/README.md
+++ b/update-bot/README.md
@@ -11,10 +11,10 @@ The paths shown here are in `~/src` but you can change them to whatever you like
 1. Clone the WLM repository: `git clone git@github.com:wmde/WikiLovesMonuments.git`.
 2. Edit `user-config.py`: insert your user name and set the absolute path for the local testing.
 3. Edit `local_family.py`: Replace the host name with your local testing host name.
-4. Clone the pywikibot repository:  
+4. Clone the pywikibot repository:
    `git clone --branch 2.0 --recursive  https://gerrit.wikimedia.org/r/pywikibot/core.git ~/src/pywikibot`
-5. Install the necessary libraries:  
-   `sudo pip install httplib2`
+5. Install the necessary libraries:
+   `pip install -r update-bot/requirements.txt`
 6. Set and export the library path:
 ```
 PYTHONPATH=$PYTHONPATH:~/src/pywikibot

--- a/update-bot/requirements.txt
+++ b/update-bot/requirements.txt
@@ -1,0 +1,2 @@
+httplib2
+mwparserfromhell


### PR DESCRIPTION
`mwparserfromhell` wasn't mentioned in the README but is required so it probably makes sense to have a `requirements.txt` with all the pip dependencies.