### PR TITLE
Commonscat detection

### DIFF
--- a/update-bot/commonscat_mapper.py
+++ b/update-bot/commonscat_mapper.py
@@ -40,6 +40,9 @@ class CommonscatMapper(object):
         u"Kategorie:Liste (Kulturdenkmale in Zittau)": u"Category:Cultural heritage ensembles in Saxony",
     }
 
+    def __init__(self):
+        self.category_cache = {}
+
     def get_commonscat_from_category_links(self, text):
         """ Get the commonscat from the Category links (which is guaranteed to
             be on every page of the WLM pages)
@@ -76,9 +79,11 @@ class CommonscatMapper(object):
                 raise
 
     def get_commonscat(self, text, template):
-        category_candidates = [
-            self.get_commonscat_from_table_row_template(template),
-            self.get_commonscat_from_weblinks_template(text),
-            self.get_commonscat_from_category_links(text)
-        ]
+        text_id = id(text)
+        if text_id not in self.category_cache:
+            self.category_cache[text_id] = [
+                self.get_commonscat_from_weblinks_template(text),
+                self.get_commonscat_from_category_links(text)
+            ]
+        category_candidates = [self.get_commonscat_from_table_row_template(template)] + self.category_cache[text_id]
         return next(category for category in category_candidates if category) # return first non-empyt element

--- a/update-bot/commonscat_mapper.py
+++ b/update-bot/commonscat_mapper.py
@@ -5,10 +5,10 @@ import re
 class CommonscatMapper(object):
 
     mapping = {
-        u"Kategorie:Liste (Kulturdenkmale in Baden-Württemberg)": u"Category:Cultural heritage monuments in Baden-Württemberg‏‎",
+        u"Kategorie:Liste (Kulturdenkmale in Baden-Württemberg)": u"Category:Cultural heritage monuments in Baden-Württemberg",
         u"Kategorie:Liste (Baudenkmäler in Bayern)": u"Category:Cultural heritage monuments in Bavaria",
         u"Kategorie:Liste (Bodendenkmäler in Bayern)": u"Category:Cultural heritage monuments in Bavaria",
-        u"Kategorie:Liste (Kulturdenkmäler in Berlin)": u"Category:Cultural heritage monuments in Berlin‏‎",
+        u"Kategorie:Liste (Kulturdenkmäler in Berlin)": u"Category:Cultural heritage monuments in Berlin",
         u"Kategorie:Liste (Baudenkmale in Brandenburg)": u"Category:Cultural heritage monuments in Brandenburg",
         u"Kategorie:Liste (Bodendenkmale in Brandenburg)": u"Category:Cultural heritage monuments in Brandenburg",
         u"Kategorie:Liste (Kulturdenkmäler in der Freien Hansestadt Bremen)": u"Category:Cultural heritage monuments in Bremen",

--- a/update-bot/commonscat_mapper.py
+++ b/update-bot/commonscat_mapper.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 import mwparserfromhell
+import re
 
 class CommonscatMapper(object):
 
     mapping = {
-        u"Kategorie:Liste (Kulturdenkmale in Baden-Württemberg)": u"Cultural heritage monuments in Baden-Württemberg‏‎",
+        u"Kategorie:Liste (Kulturdenkmale in Baden-Württemberg)": u"Category:Cultural heritage monuments in Baden-Württemberg‏‎",
         u"Kategorie:Liste (Baudenkmäler in Bayern)": u"Category:Cultural heritage monuments in Bavaria",
         u"Kategorie:Liste (Bodendenkmäler in Bayern)": u"Category:Cultural heritage monuments in Bavaria",
-        u"Kategorie:Liste (Kulturdenkmäler in Berlin)": u"Cultural heritage monuments in Berlin‏‎",
+        u"Kategorie:Liste (Kulturdenkmäler in Berlin)": u"Category:Cultural heritage monuments in Berlin‏‎",
         u"Kategorie:Liste (Baudenkmale in Brandenburg)": u"Category:Cultural heritage monuments in Brandenburg",
         u"Kategorie:Liste (Bodendenkmale in Brandenburg)": u"Category:Cultural heritage monuments in Brandenburg",
         u"Kategorie:Liste (Kulturdenkmäler in der Freien Hansestadt Bremen)": u"Category:Cultural heritage monuments in Bremen",
@@ -22,12 +23,62 @@ class CommonscatMapper(object):
         u"Kategorie:Liste (Kulturdenkmale in Sachsen)": u"Category:Cultural heritage ensembles in Saxony",
         u"Kategorie:Liste (Kulturdenkmale in Sachsen-Anhalt)": u"Category:Cultural heritage monuments in Saxony-Anhalt",
         u"Kategorie:Liste (Kulturdenkmale in Schleswig-Holstein)": u"Category:Cultural heritage monuments in Schleswig-Holstein",
-        u"Kategorie:Liste (Kulturdenkmale in Thüringen)": u"Category:Cultural heritage monuments in Thuringia"
+        u"Kategorie:Liste (Kulturdenkmale in Thüringen)": u"Category:Cultural heritage monuments in Thuringia",
+        # Saxony has nested subcategories
+        u"Kategorie:Liste (Kulturdenkmale in Bannewitz)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Bautzen)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Chemnitz)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Dresden)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Freiberg)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Freital)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Görlitz)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Leipzig)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Meißen)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Pirna)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Plauen)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Radebeul)": u"Category:Cultural heritage ensembles in Saxony",
+        u"Kategorie:Liste (Kulturdenkmale in Zittau)": u"Category:Cultural heritage ensembles in Saxony",
     }
 
-    def get_commonscat_from_links(self, text):
+    def get_commonscat_from_category_links(self, text):
+        """ Get the commonscat from the Category links (which is guaranteed to
+            be on every page of the WLM pages)
+        """
         code = mwparserfromhell.parse(text)
         for link in code.filter_wikilinks():
             title = unicode(link.title)
             if title in self.mapping:
                 return self.mapping[title]
+
+    def get_commonscat_from_weblinks_template(self, text):
+        header_pos = re.search(r'=+\s+Weblinks', text, re.IGNORECASE)
+        if not header_pos:
+            return ""
+        weblink_text = text[header_pos.start(0):]
+        for template in mwparserfromhell.parse(weblink_text).filter_templates():
+            if template.name.matches("Commonscat"):
+                return u"Category:" + unicode(template.params[0])
+        return ""
+
+    def get_commonscat_from_table_row_template(self, template):
+        """ Check mwparserfromhell template if it has a non-empty Commonscat parameter. """
+        try:
+            param = unicode(template.get("Commonscat")).strip()
+            if param:
+                _, commonscat = param.split("=", 1)
+                return u"Category:" + commonscat.strip()
+            else:
+                return ""
+        except ValueError as e:
+            if str(e) == "Commonscat":
+                return ""
+            else:
+                raise
+
+    def get_commonscat(self, text, template):
+        category_candidates = [
+            self.get_commonscat_from_table_row_template(template),
+            self.get_commonscat_from_weblinks_template(text),
+            self.get_commonscat_from_category_links(text)
+        ]
+        return next(category for category in category_candidates if category) # return first non-empyt element

--- a/update-bot/test_commonscat_mapper.py
+++ b/update-bot/test_commonscat_mapper.py
@@ -1,14 +1,93 @@
 # -*- coding: utf-8 -*-
 import unittest
+from mock import Mock
 
 import commonscat_mapper
 
 class TestStringMethods(unittest.TestCase):
 
-    def test_mapping(self):
-        mapper = commonscat_mapper.CommonscatMapper()
-        commonscat = mapper.get_commonscat_from_links(u"Foo [[Kategorie:Liste (Kulturdenkmäler in Berlin)|Liste der Kulturdenkmäler in Berlin]] Bar")
-        self.assertEqual(commonscat, u"Cultural heritage monuments in Berlin‏‎")
+    def setUp(self):
+        self.mapper = commonscat_mapper.CommonscatMapper()
+
+    def test_category_link_mapping(self):
+        commonscat = self.mapper.get_commonscat_from_category_links(u"Foo [[Kategorie:Liste (Kulturdenkmäler in Berlin)|Liste der Kulturdenkmäler in Berlin]] Bar")
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Berlin‏‎")
+
+    def test_weblinks_commonscat_template_returns_comonscat_if_exists(self):
+        commonscat = self.mapper.get_commonscat_from_weblinks_template(u"Foo\n== Weblinks ==\n {{Commonscat|Cultural heritage monuments in Bad Cannstatt|Kulturdenkmale in Bad Cannstatt}}\n Bar")
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Bad Cannstatt")
+
+    def test_weblinks_commonscat_template_returns_empty_string_when_weblinks_header_is_missing (self):
+        commonscat = self.mapper.get_commonscat_from_weblinks_template(u"Foo\n {{Commonscat|Cultural heritage monuments in Bad Cannstatt|Kulturdenkmale in Bad Cannstatt}} \n Bar")
+        self.assertEqual(commonscat, "")
+
+    def test_weblinks_commonscat_template_returns_empty_string_when_commonscat_is_missing (self):
+        commonscat = self.mapper.get_commonscat_from_weblinks_template(u"Foo\n == Weblinks ==\n[[Some page]] Bar")
+        self.assertEqual(commonscat, "")
+
+    def test_weblinks_commonscat_template_picks_the_first_commonscat_entry(self):
+        commonscat = self.mapper.get_commonscat_from_weblinks_template(u"Foo\n== Weblinks ==\n {{Commonscat|Cultural heritage monuments in Bad Cannstatt|Kulturdenkmale in Bad Cannstatt}} {{Commonscat|Cultural heritage monuments in Bad Wimpfen|Kulturdenkmale in Bad Wimpfen}}  Bar")
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Bad Cannstatt")
+
+    def test_weblinks_commonscat_template_ignores_commonscat_entries_before_weblinks_header(self):
+        commonscat = self.mapper.get_commonscat_from_weblinks_template(u"{{Commonscat|Cultural heritage monuments in Bad Cannstatt|Kulturdenkmale in Bad Cannstatt}} \n== Weblinks ==\n {{Commonscat|Cultural heritage monuments in Bad Wimpfen|Kulturdenkmale in Bad Wimpfen}}\n  Bar")
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Bad Wimpfen")
+
+    def test_commonscat_from_table_row_template_returns_commonscat_if_it_is_not_empty(self):
+        template = Mock()
+        template.get.return_value = u"Commonscat=Cultural heritage monuments in Berlin‏‎"
+        commonscat = self.mapper.get_commonscat_from_table_row_template(template)
+        template.get.assert_called_once_with("Commonscat")
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Berlin‏‎")
+
+    def test_commonscat_from_table_row_template_strips_whitespace_from_commonscat(self):
+        template = Mock()
+        template.get.return_value = u"Commonscat = Cultural heritage monuments in Berlin‏‎    \n"
+        commonscat = self.mapper.get_commonscat_from_table_row_template(template)
+        template.get.assert_called_once_with("Commonscat")
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Berlin‏‎")
+
+    def test_commonscat_from_table_row_template_returns_empty_string_if_it_is_empty(self):
+        template = Mock()
+        template.get.return_value = u""
+        commonscat = self.mapper.get_commonscat_from_table_row_template(template)
+        template.get.assert_called_once_with("Commonscat")
+        self.assertEqual(commonscat, u"")
+
+    def test_commonscat_from_table_row_template_returns_empty_string_if_it_consists_only_of_whitespace(self):
+        template = Mock()
+        template.get.return_value = u"    \n"
+        commonscat = self.mapper.get_commonscat_from_table_row_template(template)
+        template.get.assert_called_once_with("Commonscat")
+        self.assertEqual(commonscat, u"")
+
+    def test_commonscat_from_table_row_template_returns_empty_string_if_template_throws_value_error_with_commonscat_as_message(self):
+        template = Mock()
+        template.get.side_effect=ValueError("Commonscat")
+        commonscat = self.mapper.get_commonscat_from_table_row_template(template)
+        template.get.assert_called_once_with("Commonscat")
+        self.assertEqual(commonscat, u"")
+
+    def test_get_commonscat_returns_commonscat_from_template_row_if_it_exists(self):
+        template = Mock()
+        template.get.return_value = u"Commonscat=Cultural heritage monuments in Meetschow"
+        pagetext = u"Foo\n== Weblinks ==\n{{Commonscat|Cultural heritage monuments in Gorleben|Baudenkmale in Gorleben}}  \n[[Kategorie:Liste (Baudenkmale in Niedersachsen)|Gorleben]] Bar"
+        commonscat = self.mapper.get_commonscat(pagetext, template)
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Meetschow")
+
+    def test_get_commonscat_returns_commonscat_from_weblinks_if_table_row_is_empty(self):
+        template = Mock()
+        template.get.return_value = u""
+        pagetext = u"Foo\n== Weblinks ==\n{{Commonscat|Cultural heritage monuments in Gorleben|Baudenkmale in Gorleben}}  \n[[Kategorie:Liste (Baudenkmale in Niedersachsen)|Gorleben]] Bar"
+        commonscat = self.mapper.get_commonscat(pagetext, template)
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Gorleben")
+
+    def test_get_commonscat_returns_commonscat_from_category_links_if_table_row_and_commonscat_template_are_empty(self):
+        template = Mock()
+        template.get.return_value = u""
+        pagetext = u"Foo \n[[Kategorie:Liste (Baudenkmale in Niedersachsen)|Gorleben]] Bar"
+        commonscat = self.mapper.get_commonscat(pagetext, template)
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Lower Saxony")
 
 if __name__ == '__main__':
     unittest.main()

--- a/update-bot/test_commonscat_mapper.py
+++ b/update-bot/test_commonscat_mapper.py
@@ -11,7 +11,7 @@ class TestStringMethods(unittest.TestCase):
 
     def test_category_link_mapping(self):
         commonscat = self.mapper.get_commonscat_from_category_links(u"Foo [[Kategorie:Liste (Kulturdenkmäler in Berlin)|Liste der Kulturdenkmäler in Berlin]] Bar")
-        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Berlin‏‎")
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Berlin")
 
     def test_weblinks_commonscat_template_returns_comonscat_if_exists(self):
         commonscat = self.mapper.get_commonscat_from_weblinks_template(u"Foo\n== Weblinks ==\n {{Commonscat|Cultural heritage monuments in Bad Cannstatt|Kulturdenkmale in Bad Cannstatt}}\n Bar")
@@ -35,17 +35,17 @@ class TestStringMethods(unittest.TestCase):
 
     def test_commonscat_from_table_row_template_returns_commonscat_if_it_is_not_empty(self):
         template = Mock()
-        template.get.return_value = u"Commonscat=Cultural heritage monuments in Berlin‏‎"
+        template.get.return_value = u"Commonscat=Cultural heritage monuments in Berlin"
         commonscat = self.mapper.get_commonscat_from_table_row_template(template)
         template.get.assert_called_once_with("Commonscat")
-        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Berlin‏‎")
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Berlin")
 
     def test_commonscat_from_table_row_template_strips_whitespace_from_commonscat(self):
         template = Mock()
-        template.get.return_value = u"Commonscat = Cultural heritage monuments in Berlin‏‎    \n"
+        template.get.return_value = u"Commonscat = Cultural heritage monuments in Berlin   \n"
         commonscat = self.mapper.get_commonscat_from_table_row_template(template)
         template.get.assert_called_once_with("Commonscat")
-        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Berlin‏‎")
+        self.assertEqual(commonscat, u"Category:Cultural heritage monuments in Berlin")
 
     def test_commonscat_from_table_row_template_returns_empty_string_if_it_is_empty(self):
         template = Mock()

--- a/update-bot/test_update_bot.py
+++ b/update-bot/test_update_bot.py
@@ -1,35 +1,34 @@
 # -*- coding: utf-8 -*-
 import unittest
-from mock import MagicMock # unittest.mock for Python >= 3.3
+from mock import Mock # unittest.mock for Python >= 3.3
 
 import update_bot
 
 class TestUpdateBot(unittest.TestCase):
 
     def test_replace_in_templates_does_nothing_if_image_exists(self):
-        article_text = "{{Denkmalliste Bayern Tabellenzeile|Bild=Kruzifix.jpg}}"
-        new_text = update_bot.replace_in_templates(article_text, "")
+        article_text = "{{Denkmalliste Bayern Tabellenzeile|Bild=Kruzifix.jpg|Commonscat=testcategory}}"
+        new_text = update_bot.replace_in_templates(article_text)
         self.assertEqual(new_text, article_text)
 
     def test_replace_in_templates_inserts_placeholder_when_image_is_missing(self):
-        article_text = "{{Denkmalliste Bayern Tabellenzeile|Bild=}}"
+        article_text = "{{Denkmalliste Bayern Tabellenzeile|Bild=|Commonscat=testcategory}}"
         update_bot.WLM_PLACEHOLDER = "<-- test placeholder -->"
-        new_text = update_bot.replace_in_templates(article_text, "")
-        self.assertEqual(new_text, "{{Denkmalliste Bayern Tabellenzeile|Bild=<-- test placeholder -->}}")
+        new_text = update_bot.replace_in_templates(article_text)
+        self.assertEqual(new_text, "{{Denkmalliste Bayern Tabellenzeile|Bild=<-- test placeholder -->|Commonscat=testcategory}}")
 
     def test_replace_in_templates_inserts_commoncat_in_placeholder(self):
-        article_text = "{{Denkmalliste Bayern Tabellenzeile|Bild=}}"
+        article_text = "{{Denkmalliste Bayern Tabellenzeile|Bild=\n|Commonscat=testcategory\n}}"
         update_bot.WLM_PLACEHOLDER = "<-- #commonscat# -->"
-        new_text = update_bot.replace_in_templates(article_text, "testcategory")
-        self.assertEqual(new_text, "{{Denkmalliste Bayern Tabellenzeile|Bild=<-- testcategory -->}}")
+        new_text = update_bot.replace_in_templates(article_text)
+        self.assertEqual(new_text, "{{Denkmalliste Bayern Tabellenzeile|Bild=<-- Category:testcategory -->\n|Commonscat=testcategory\n}}")
 
     def test_add_placeholders_does_nothing_if_category_link_is_missing(self):
-        article = MagicMock()
+        article = Mock()
         article.get.return_value = "{{Denkmalliste Bayern Tabellenzeile|Bild=}}"
         article.title.return_value = "Testseite"
         article.save.assert_not_called()
         update_bot.add_placeholders(article)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The CommonscatMapper class now tries to determine the most specific commons category from three sources: The table row template, the Commonscat template in the "Weblinks" section of a page and the category links of a page.