### PR TITLE
Fix test case names

### DIFF
--- a/update-bot/tests/test_commonscat_mapper.py
+++ b/update-bot/tests/test_commonscat_mapper.py
@@ -6,7 +6,7 @@ from mock import Mock
 from wlmbots.lib import commonscat_mapper
 
 
-class TestStringMethods(unittest.TestCase):
+class TestCommonscatMapper(unittest.TestCase):
 
     def setUp(self):
         self.mapper = commonscat_mapper.CommonscatMapper()

--- a/update-bot/tests/test_template_replacer.py
+++ b/update-bot/tests/test_template_replacer.py
@@ -9,7 +9,7 @@ class TemplateForTesting(object):
         self.name = name
         self.params = params
 
-class TestStringMethods(unittest.TestCase):
+class TestTemplateReplacer(unittest.TestCase):
 
     def test_get_value_returns_values(self):
         fixture = TemplateForTesting("", [u"a=5", u"b=Übertrag"])


### PR DESCRIPTION
Test case names were copy-pasted from unittest docs. Had no effect on
functionality, but is more consistent now.