### PR TITLE
Add default values to params in if expressions

### DIFF
--- a/update-bot/wiki_templates/LinkToCommons.wiki.txt
+++ b/update-bot/wiki_templates/LinkToCommons.wiki.txt
@@ -11,5 +11,5 @@ This template creates a link to the Upload Wizard. The following parameters can 
 * '''Link_Text'''
 : The text being displayed as the link; currently defaults to "Bild gesucht"
 </noinclude>
-<onlyinclude>[{{SERVER}}/wiki/Special:UploadWizard?campaign={{{Campaign}}}&categories={{{Categories}}}{{#if:{{{Lat}}}|&lat={{{Lat}}}}}{{#if:{{{Lon}}}|&lon={{{Lon}}}}}{{#if:{{{ID}}}|&objref=dewiki{{!}}{{urlencode:{{PAGENAME}}}}{{!}}{{urlencode:{{{ID}}}}}}} {{{Link_Text|Bild gesucht}}}]</onlyinclude>
+<onlyinclude>[{{SERVER}}/wiki/Special:UploadWizard?campaign={{{Campaign}}}&categories={{{Categories}}}{{#if:{{{Lat|}}}|&lat={{{Lat}}}}}{{#if:{{{Lon|}}}|&lon={{{Lon}}}}}{{#if:{{{ID|}}}|&objref=dewiki{{!}}{{urlencode:{{PAGENAME}}}}{{!}}{{urlencode:{{{ID}}}}}}} {{{Link_Text|Bild gesucht}}}]</onlyinclude>
 


### PR DESCRIPTION
When using params in if expressions, they need a blank default value, see https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions#.23if