### PR TITLE
Ignore pywikibot.lwp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ update-bot/throttle.ctrl
 update-bot/Denkmallistenliste.txt
 update-bot/local_family.py
 update-bot/user-config.py
+**pywikibot.lwp


### PR DESCRIPTION
Those files contain cookie information and should never be in version
control.