### PR TITLE
Fix category parameter

### DIFF
--- a/update-bot/tests/test_article_iterator.py
+++ b/update-bot/tests/test_article_iterator.py
@@ -103,6 +103,23 @@ class TestArticleIteratorArgumentParser(unittest.TestCase):
         self.assertTrue(parser.check_argument(u"-category:Baudenkmäler in Sachsen"))
         self.assertEqual(article_iterator.categories, [category])
 
+    def test_category_is_cleaned_up(self):
+        article_iterator = Mock()
+        pagelister = Mock()
+        category = Mock()
+        pagelister.get_county_categories_by_name.return_value = [category]
+        parser = ArticleIteratorArgumentParser(article_iterator, pagelister)
+        self.assertTrue(parser.check_argument(u"-category:Baudenkmäler_in_Sachsen"))
+        pagelister.get_county_categories_by_name.assert_called_once_with([u"Kategorie:Baudenkmäler in Sachsen"])
+
+    def test_multiple_categories_are_supported(self):
+        article_iterator = Mock()
+        pagelister = Mock()
+        category = Mock()
+        pagelister.get_county_categories_by_name.return_value = [category]
+        parser = ArticleIteratorArgumentParser(article_iterator, pagelister)
+        self.assertTrue(parser.check_argument(u"-category:Baudenkmäler_in_Sachsen,Baudenkmäler in Bayern"))
+        pagelister.get_county_categories_by_name.assert_called_once_with([u"Kategorie:Baudenkmäler in Sachsen", u"Kategorie:Baudenkmäler in Bayern"])
 
 if __name__ == '__main__':
     unittest.main()

--- a/update-bot/wlmbots/lib/article_iterator.py
+++ b/update-bot/wlmbots/lib/article_iterator.py
@@ -61,7 +61,14 @@ class ArticleIteratorArgumentParser(object):
             return True
         elif argument.find("-category:") == 0:
             category_names = argument[10:].split(",")
+            category_names = [self._format_category(n) for n in category_names]
             self.article_iterator.categories = self.pagelister.get_county_categories_by_name(category_names)
             return True
         else:
             return False
+
+    def _format_category(self, category_name):
+        name = category_name.strip().replace(u"_", u" ")
+        if name.find(u"Kategorie:") == -1 and name.find(u"Category:") == -1:
+            name = u"Kategorie:{}".format(name)
+        return name


### PR DESCRIPTION
-category: parameter was not working because the leading "Kategorie:"
was missing. Also made it more robust by removing whitespace and
replacing underscores with spaces.