### PR TITLE
Fix off-by-one error in ArticleIterator

### DIFF
--- a/update-bot/tests/test_article_iterator.py
+++ b/update-bot/tests/test_article_iterator.py
@@ -32,7 +32,8 @@ class TestArticleIterator(unittest.TestCase):
 
     def test_article_iterator_with_limit_stops_at_limit(self):
         category_callback = Mock()
-        iterator = ArticleIterator(category_callback=category_callback)
+        article_callback = Mock()
+        iterator = ArticleIterator(category_callback=category_callback, article_callback=article_callback)
         iterator.limit = 10
         articles = [Mock()] * 20
         category = Mock()
@@ -40,6 +41,7 @@ class TestArticleIterator(unittest.TestCase):
         iterator.categories = [category]
         iterator.iterate_categories()
         category_callback.assert_called_once_with(category=category, counter=10, article_iterator=iterator)
+        self.assertEqual(article_callback.call_count, 10)
 
 
     def test_article_iterator_with_multiple_categories_stops_at_limit(self):

--- a/update-bot/wlmbots/lib/article_iterator.py
+++ b/update-bot/wlmbots/lib/article_iterator.py
@@ -35,14 +35,14 @@ class ArticleIterator(object):
 
     def iterate_articles(self, category, counter):
         for article in category.articles():
+            if self.limit and counter >= self.limit:
+                return counter
             if self.logging_callback and counter % self.log_every_n == 0:
                 self.logging_callback("Fetching page {} ({})".format(counter, article.title()))
             if self.article_callback:
                 self.article_callback(article=article, category=category, counter=counter,
                                       article_iterator=self)
             counter += 1
-            if self.limit and counter > self.limit:
-                return counter - 1  # Decrease counter by one because to reflect the real number of processed items
         return counter
 
 


### PR DESCRIPTION
There was one article iterated too many if there was alimit. Now the
limit and the counter is more "natural": Limit is the number of items
and the counter still starts at 0.