### PR TITLE
Add log messages to checker bot

### DIFF
--- a/update-bot/wlmbots/checker_bot.py
+++ b/update-bot/wlmbots/checker_bot.py
@@ -112,6 +112,7 @@ def main(*args):
     article_iterator = ArticleIterator(
         category_callback=checker_bot.cb_store_category_result,
         article_callback=checker_bot.cb_check_article,
+        logging_callback=pywikibot.log,
         categories=pagelister.get_county_categories()
     )
     parser = ArticleIteratorArgumentParser(article_iterator, pagelister)

--- a/update-bot/wlmbots/lib/article_iterator.py
+++ b/update-bot/wlmbots/lib/article_iterator.py
@@ -38,7 +38,7 @@ class ArticleIterator(object):
             if self.limit and counter >= self.limit:
                 return counter
             if self.logging_callback and counter % self.log_every_n == 0:
-                self.logging_callback("Fetching page {} ({})".format(counter, article.title()))
+                self.logging_callback(u"Fetching page {} ({})".format(counter, article.title()))
             if self.article_callback:
                 self.article_callback(article=article, category=category, counter=counter,
                                       article_iterator=self)


### PR DESCRIPTION
Checker bot now outputs the progress every 100 pages when started with
the --verbose argument.

Fix string encoding when calling logging.