### PR TITLE
Improve regexes for ID checking

### DIFF
--- a/update-bot/config/templates.json
+++ b/update-bot/config/templates.json
@@ -1,13 +1,13 @@
 {
       "Denkmalliste Bayern Tabellenzeile": {
           "id": "Nummer",
-          "id_check": "D-\\d-\\d{3}-\\d{3}-\\d{3}",
+          "id_check": "D-\\d-\\d{1,3}-\\d{1,3}-\\d{1,3}",
           "id_check_description": "Nummer im Format D-n-nnn-nnn-nnn"
       },
       "Denkmalliste Brandenburg Tabellenzeile": {
           "id": "ID",
           "id_check": "\\d{8}",
-          "id_check_description": "achtstellige Nummer"
+          "id_check_description": "Achtstellige Nummer"
       },
       "Denkmalliste Hamburg Tabellenzeile": {
           "id": "Nummer",
@@ -16,8 +16,8 @@
       },
       "Denkmalliste Hessen Tabellenzeile": {
           "id": "Nummer",
-          "id_check": "\\d{4,}",
-          "id_check_description": "Nummer, mindestens vierstellig"
+          "id_check": "\\d{3,}",
+          "id_check_description": "Nummer, mindestens dreistellig"
       },
       "Denkmalliste1 Tabellenzeile": {
           "id": "Nummer",
@@ -36,8 +36,8 @@
       },
       "Denkmalliste Sachsen-Anhalt Tabellenzeile": {
           "id": "ID",
-          "id_check": "\\d{8}",
-          "id_check_description": "achtstellige Nummer"
+          "id_check": "\\d{3}\\s*\\d{5}",
+          "id_check_description": "Achtstellige Nummer im Format nnn nnnnn"
       },
       "Denkmalliste Thüringen Tabellenzeile": {
           "id": "ID",


### PR DESCRIPTION
After running the checker bot and getting wrong results for some IDs
(https://de.wikipedia.org/w/index.php?title=Wikipedia:Wiki_Loves_Monuments_2015/Deutschland/Technische_Unterst%C3%BCtzung/Anzupassende_Listen&oldid=144581498
) the ID patterns fro Bavaria, Hesse and Saxonia-Anhalt must be changed.