### PR TITLE
Refactor ArticleIterator callbacks

### DIFF
--- a/update-bot/tests/test_article_iterator.py
+++ b/update-bot/tests/test_article_iterator.py
@@ -3,7 +3,7 @@ import unittest
 
 from mock import Mock  # unittest.mock for Python >= 3.3
 
-from wlmbots.lib.article_iterator import ArticleIterator, ArticleIteratorArgumentParser
+from wlmbots.lib.article_iterator import ArticleIterator, ArticleIteratorArgumentParser, ArticleIteratorCallbacks
 
 
 class TestArticleIterator(unittest.TestCase):
@@ -137,6 +137,41 @@ class TestArticleIteratorArgumentParser(unittest.TestCase):
         parser = ArticleIteratorArgumentParser(article_iterator, pagelister)
         self.assertTrue(parser.check_argument(u"-category:Baudenkmäler_in_Sachsen,Baudenkmäler in Bayern"))
         pagelister.get_county_categories_by_name.assert_called_once_with([u"Kategorie:Baudenkmäler in Sachsen", u"Kategorie:Baudenkmäler in Bayern"])
+
+class TestArticleIteratorCallbacks(unittest.TestCase):
+
+    def test_callback_exists_returns_correct_value(self):
+        cb = ArticleIteratorCallbacks(category_callback=Mock())
+        self.assertTrue(cb.has_callback("category"))
+        self.assertFalse(cb.has_callback("article"))
+        self.assertFalse(cb.has_callback("logging"))
+
+    def test_logging_callback_can_be_called(self):
+        logging_callback = Mock()
+        cb = ArticleIteratorCallbacks(logging_callback=logging_callback)
+        cb("logging", "foo")
+        logging_callback.assert_called_once_with("foo")
+
+    def test_article_callback_can_be_called(self):
+        article_callback = Mock()
+        article = Mock()
+        cb = ArticleIteratorCallbacks(article_callback=article_callback)
+        cb("article", article=article, counter=0)
+        article_callback.assert_called_once_with(article=article, counter=0)
+
+    def test_category_callback_can_be_called(self):
+        article_callback = Mock()
+        article = Mock()
+        cb = ArticleIteratorCallbacks(article_callback=article_callback)
+        cb("article", article=article, counter=0)
+        article_callback.assert_called_once_with(article=article, counter=0)
+
+    def test_unconfigured_callbacks_are_ignored(self):
+        # just to check if there is no exception
+        cb = ArticleIteratorCallbacks()
+        article = Mock()
+        cb("article", article=article, counter=0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/update-bot/tests/test_article_iterator.py
+++ b/update-bot/tests/test_article_iterator.py
@@ -14,7 +14,7 @@ class TestArticleIterator(unittest.TestCase):
         category.articles.return_value = []
         iterator.categories = [category]
         iterator.iterate_categories()
-        callbacks.assert_called_once_with("category", category=category, counter=0, article_iterator=iterator)
+        callbacks.category.assert_called_once_with(category=category, counter=0, article_iterator=iterator)
 
     def test_article_iterator_iterates_over_articles(self):
         callbacks = Mock()
@@ -25,8 +25,8 @@ class TestArticleIterator(unittest.TestCase):
         category.articles.return_value = [article1, article2]
         iterator.categories = [category]
         iterator.iterate_categories()
-        callbacks.assert_any_call("article", article=article1, category=category, counter=0, article_iterator=iterator)
-        callbacks.assert_any_call("article", article=article2, category=category, counter=1, article_iterator=iterator)
+        callbacks.article.assert_any_call(article=article1, category=category, counter=0, article_iterator=iterator)
+        callbacks.article.assert_any_call(article=article2, category=category, counter=1, article_iterator=iterator)
 
     def test_article_iterator_with_limit_stops_at_limit(self):
         category_callback = Mock()
@@ -143,39 +143,34 @@ class TestArticleIteratorArgumentParser(unittest.TestCase):
         self.assertTrue(parser.check_argument(u"-category:Baudenkmäler_in_Sachsen,Baudenkmäler in Bayern"))
         pagelister.get_county_categories_by_name.assert_called_once_with([u"Kategorie:Baudenkmäler in Sachsen", u"Kategorie:Baudenkmäler in Bayern"])
 
-class TestArticleIteratorCallbacks(unittest.TestCase):
 
-    def test_callback_exists_returns_correct_value(self):
-        callbacks = ArticleIteratorCallbacks(category_callback=Mock())
-        self.assertTrue(callbacks.has_callback("category"))
-        self.assertFalse(callbacks.has_callback("article"))
-        self.assertFalse(callbacks.has_callback("logging"))
+class TestArticleIteratorCallbacks(unittest.TestCase):
 
     def test_logging_callback_can_be_called(self):
         logging_callback = Mock()
         callbacks = ArticleIteratorCallbacks(logging_callback=logging_callback)
-        callbacks("logging", "foo")
+        callbacks.logging("foo")
         logging_callback.assert_called_once_with("foo")
 
     def test_article_callback_can_be_called(self):
         article_callback = Mock()
         article = Mock()
         callbacks = ArticleIteratorCallbacks(article_callback=article_callback)
-        callbacks("article", article=article, counter=0)
+        callbacks.article(article=article, counter=0)
         article_callback.assert_called_once_with(article=article, counter=0)
 
     def test_category_callback_can_be_called(self):
-        article_callback = Mock()
+        category_callback = Mock()
         article = Mock()
-        callbacks = ArticleIteratorCallbacks(article_callback=article_callback)
-        callbacks("article", article=article, counter=0)
-        article_callback.assert_called_once_with(article=article, counter=0)
+        callbacks = ArticleIteratorCallbacks(category_callback=category_callback)
+        callbacks.category(article=article, counter=0)
+        category_callback.assert_called_once_with(article=article, counter=0)
 
     def test_unconfigured_callbacks_are_ignored(self):
         # just to check if there is no exception
         callbacks = ArticleIteratorCallbacks()
         article = Mock()
-        callbacks("article", article=article, counter=0)
+        callbacks.article(article=article, counter=0)
 
 
 if __name__ == '__main__':

--- a/update-bot/wlmbots/checker_bot.py
+++ b/update-bot/wlmbots/checker_bot.py
@@ -24,7 +24,7 @@ import pywikibot
 
 from wlmbots.lib.template_checker import TemplateChecker
 from wlmbots.lib.pagelist import Pagelist
-from wlmbots.lib.article_iterator import ArticleIterator, ArticleIteratorArgumentParser
+from wlmbots.lib.article_iterator import ArticleIterator, ArticleIteratorArgumentParser, ArticleIteratorCallbacks
 
 
 class CheckerBot(object):

--- a/update-bot/wlmbots/checker_bot.py
+++ b/update-bot/wlmbots/checker_bot.py
@@ -182,12 +182,12 @@ def main(*args):
     checker.load_config("config/templates.json")
     checker_bot = CheckerBot(checker, site)
     all_categories = pagelister.get_county_categories()
-    article_iterator = ArticleIterator(
+    callbacks = ArticleIteratorCallbacks(
         category_callback=checker_bot.cb_store_category_result,
         article_callback=checker_bot.cb_check_article,
         logging_callback=pywikibot.log,
-        categories=all_categories
     )
+    article_iterator = ArticleIterator(callbacks, categories=all_categories)
     parser = ArticleIteratorArgumentParser(article_iterator, pagelister)
     for argument in pywikibot.handle_args(args):
         if parser.check_argument(argument):

--- a/update-bot/wlmbots/lib/article_iterator.py
+++ b/update-bot/wlmbots/lib/article_iterator.py
@@ -64,6 +64,25 @@ class ArticleIterator(object):
                 self.limit and counter >= self.limit
             )
 
+class ArticleIteratorCallbacks(object):
+
+    def __init__(self, category_callback=None, article_callback=None, logging_callback=None):
+        self.category = category_callback
+        self.article = article_callback
+        self.logging = logging_callback
+
+    def has_callback(self, name):
+        return getattr(self, name) is not None
+
+    def __call__(self, name, *args, **kwargs):
+        """
+        Dispatch call to callback function or return None if no callback
+        function is configured.
+        """
+        if self.has_callback(name):
+            return getattr(self, name)(*args, **kwargs)
+        else:
+            return None
 
 class ArticleIteratorArgumentParser(object):
     """ Parse command line arguments -limit: and -category: and set to ArticleIterator """


### PR DESCRIPTION
Callbacks are now put into their own class. This reduces the number of constructor params and the number of checks in ArticleIterator.
