### PR TITLE
Checkerbot exclude list

### DIFF
--- a/update-bot/tests/test_article_iterator.py
+++ b/update-bot/tests/test_article_iterator.py
@@ -98,6 +98,21 @@ class TestArticleIterator(unittest.TestCase):
         log_callback.assert_any_call(u"Fetching page 0 (Foo)")
         log_callback.assert_any_call(u"Fetching page 1 (Bar)")
 
+    def test_excluded_articles_are_skipped(self):
+        article_callback = Mock()
+        callbacks = ArticleIteratorCallbacks(article_callback=article_callback)
+        iterator = ArticleIterator(callbacks)
+        article1 = Mock()
+        article2 = Mock()
+        article1.title.return_value = "Foo"
+        article2.title.return_value = "Bar"
+        category = Mock()
+        category.articles.return_value = [article1, article2]
+        iterator.categories = [category]
+        iterator.excluded_articles = ["Foo"]
+        iterator.iterate_categories()
+        article_callback.assert_called_once_with(article=article2, category=category, counter=0, article_iterator=iterator)
+
 
 class TestArticleIteratorArgumentParser(unittest.TestCase):
     def test_limit_is_set(self):

--- a/update-bot/tests/test_checker_bot.py
+++ b/update-bot/tests/test_checker_bot.py
@@ -146,6 +146,19 @@ class TestCheckerBot(unittest.TestCase):
         self.assertIn(u"IDs_ungueltig=|", table)
         self.assertIn(u"IDs_doppelt=|", table)
 
+    def test_exluded_articles_returns_empty_list_if_page_does_not_exist(self):
+        page = Mock()
+        page.exists.return_value = False
+        self.assertEqual(checker_bot.load_excluded_articles_from_wiki(page), [])
+
+    def test_exluded_articles_returns_list_of_page_names_in_lines(self):
+        page = Mock()
+        page.exists.return_value = True
+        page.get.return_value = u"[[Foo]] This is a test\r\n[[Bar]]\n[[Baz|Description text]]"
+        self.assertEqual(checker_bot.load_excluded_articles_from_wiki(page), [
+            u"Foo", u"Bar", u"Baz"
+        ])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/update-bot/wlmbots/lib/article_iterator.py
+++ b/update-bot/wlmbots/lib/article_iterator.py
@@ -17,6 +17,7 @@ class ArticleIterator(object):
         self.callbacks = callbacks
         categories = [] if categories is None else categories
         self.categories = categories
+        self._excluded_articles = {}
 
     def iterate_categories(self):
         counter = 0
@@ -34,6 +35,8 @@ class ArticleIterator(object):
         for article in category.articles(**kwargs):
             if self._limit_reached(counter, category_counter):
                 return counter
+            if self._excluded_articles and article.title() in self._excluded_articles:
+                continue
             if counter % self.log_every_n == 0:
                 self.callbacks("logging", u"Fetching page {} ({})".format(counter, article.title()))
             self.callbacks("article", article=article, category=category, counter=counter,
@@ -41,6 +44,14 @@ class ArticleIterator(object):
             counter += 1
             category_counter += 1
         return counter
+
+    @property
+    def excluded_articles(self):
+        return self._excluded_articles.keys()
+
+    @excluded_articles.setter
+    def excluded_articles(self, value):
+        self._excluded_articles = {i : True for i in value}
 
     def _get_default_article_arguments(self):
         args = {}

--- a/update-bot/wlmbots/lib/article_iterator.py
+++ b/update-bot/wlmbots/lib/article_iterator.py
@@ -15,10 +15,8 @@ class ArticleIterator(object):
         self.articles_per_category_limit = 0
         self.log_every_n = 100
         self.callbacks = callbacks
-        if categories:
-            self.categories = categories
-        else:
-            self.categories = []
+        categories = [] if categories is None else categories
+        self.categories = categories
 
     def iterate_categories(self):
         counter = 0

--- a/update-bot/wlmbots/lib/article_iterator.py
+++ b/update-bot/wlmbots/lib/article_iterator.py
@@ -15,8 +15,7 @@ class ArticleIterator(object):
         self.articles_per_category_limit = 0
         self.log_every_n = 100
         self.callbacks = callbacks
-        categories = [] if categories is None else categories
-        self.categories = categories
+        self.categories = [] if categories is None else categories
         self._excluded_articles = {}
 
     def iterate_categories(self):


### PR DESCRIPTION
checker_bot now supports an additional parameter `-exclude-articles:` that reads a wiki page and ignores all pages that are linked on it.