### PR TITLE
Remove path prefix on tool labs

### DIFF
--- a/forward_script/web/index.php
+++ b/forward_script/web/index.php
@@ -1,5 +1,12 @@
 <?php
 
+// Remove prefix on tool labs to make our routes work behind the reverse proxy
+if ( !empty( $_SERVER['HTTP_X_ORIGINAL_URI'] ) ) {
+	foreach ( ['HTTP_X_ORIGINAL_URI', 'REQUEST_URI'] as $serverVar ) {
+		$_SERVER[$serverVar] = preg_replace( "!^/wlm-de-utils!", '', $_SERVER[$serverVar] );
+	}
+}
+
 $app = require __DIR__ . '/../app.php';
 
 $app->run();


### PR DESCRIPTION
On tool labs, the routes break because the reverse proxy adds a subdirectory path (the tool name). Probaly there is a better way to fix this (lighttpd config, Silex middleware), but directly manipulating
`$_SERVER` works as a quick fix.