### PR TITLE
PHP error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ update-bot/user-config.py
 **pywikibot.lwp
 forward_script/vendor
 forward_script/cache
+forward_script/app_errors.log
+

--- a/forward_script/app.php
+++ b/forward_script/app.php
@@ -40,6 +40,10 @@ $app['pageinfo'] = $app->share( function ( $app ) {
 	$process = new Process( $app['pageinfo_script'], $app['python_path'] );
 	return new PageInformationCollector( $app[ 'wikipedia_api' ], $process, $defaultCategories );
 } );
+$app->register( new Silex\Provider\MonologServiceProvider(), array(
+	'monolog.logfile' => __DIR__.'/app_errors.log',
+	'monolog.level' => 'WARNING'
+) );
 
 // Error handling
 $app->error( function ( ApplicationException $e, $code ) use ( $app ) {

--- a/forward_script/app.php
+++ b/forward_script/app.php
@@ -3,8 +3,10 @@
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\RuntimeException as ProcessException;
 use Wikimedia\ForwardScript\PageInformationCollector;
 use Wikimedia\ForwardScript\ApplicationException;
+use Wikimedia\ForwardScript\ErrorResponse;
 
 require __DIR__.'/vendor/autoload.php';
 
@@ -40,16 +42,12 @@ $app['pageinfo'] = $app->share( function ( $app ) {
 } );
 
 // Error handling
-$app->error( function ( ApplicationException $e, $code ) {
-	$response = new Response( $e->getMessage() );
-	$response->headers->set( 'Content-Type', 'text/plain' );
-	return $response;
+$app->error( function ( ApplicationException $e, $code ) use ( $app ) {
+	return new ErrorResponse( $e->getMessage() );
 } );
 
-$app->error( function ( \Symfony\Component\Process\Exception\RuntimeException $e, $code ) {
-	$response = new Response( $e->getMessage() );
-	$response->headers->set( 'Content-Type', 'text/plain' );
-	return $response;
+$app->error( function ( ProcessException $e, $code ) use ( $app ) {
+	return new ErrorResponse( $e->getMessage() );
 } );
 
 // Routes

--- a/forward_script/composer.json
+++ b/forward_script/composer.json
@@ -10,7 +10,8 @@
         "silex/silex": "^1.3",
         "addwiki/mediawiki-api-base": "~0.3.0",
         "doctrine/cache": "~1.0",
-        "symfony/process": "^2.7"
+        "symfony/process": "^2.7",
+        "monolog/monolog": "^1.16"
     },
     "authors": [
         {

--- a/forward_script/composer.lock
+++ b/forward_script/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f0b1f3ae35069b9f96a52a7de9b09c4e",
+    "hash": "f0a89cb8aa190d29b584c57955797a3a",
     "packages": [
         {
             "name": "addwiki/mediawiki-api-base",
@@ -272,6 +272,82 @@
                 "stream"
             ],
             "time": "2014-10-12 19:18:40"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "c0c0b4bee3aabce7182876b0d912ef2595563db7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c0c0b4bee3aabce7182876b0d912ef2595563db7",
+                "reference": "c0c0b4bee3aabce7182876b0d912ef2595563db7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9",
+                "doctrine/couchdb": "~1.0@dev",
+                "graylog2/gelf-php": "~1.0",
+                "php-console/php-console": "^3.1.3",
+                "phpunit/phpunit": "~4.5",
+                "phpunit/phpunit-mock-objects": "2.3.0",
+                "raven/raven": "~0.8",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "swiftmailer/swiftmailer": "~5.3",
+                "videlalvaro/php-amqplib": "~2.4"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "raven/raven": "Allow sending log messages to a Sentry server",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.16.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2015-08-09 17:44:44"
         },
         {
             "name": "pimple/pimple",

--- a/forward_script/src/ErrorResponse.php
+++ b/forward_script/src/ErrorResponse.php
@@ -15,8 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
  * This is a special response for errors that can be handled well and should
  * display an informative message to the user.
  *
- * It creates a 200 OK HTTP status code because otherwise the user would
+ * It creates a 'X-Wikimedia-Debug' header because otherwise the user would
  * see the default Tool Labs error page.
+ * See https://wikitech.wikimedia.org/wiki/Help:Tool_Labs/Web#Error_pages
  *
  * It uses text/plain content type to avoid the need for HTML escaping.
  *
@@ -26,10 +27,8 @@ class ErrorResponse extends Response {
 	public function __construct( $content = '', $status = 200, $headers = array() ) {
 		$headers = array_merge(
 			[
-				// The normal status code will be overwritten by the Silex handler,
-				// see http://silex.sensiolabs.org/doc/usage.html#error-handlers
-				'X-Status-Code' => Response::HTTP_OK,
-				'Content-Type' => 'text/plain'
+				'Content-Type' => 'text/plain',
+				' X-Wikimedia-Debug' => '1'
 			],
 			$headers
 		);

--- a/forward_script/src/ErrorResponse.php
+++ b/forward_script/src/ErrorResponse.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: gabi
- * Date: 19.08.15
- * Time: 12:55
- */
 
 namespace Wikimedia\ForwardScript;
-
 
 use Symfony\Component\HttpFoundation\Response;
 
@@ -34,6 +27,4 @@ class ErrorResponse extends Response {
 		);
 		parent::__construct( $content, $status, $headers );
 	}
-
-
 }

--- a/forward_script/src/ErrorResponse.php
+++ b/forward_script/src/ErrorResponse.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: gabi
+ * Date: 19.08.15
+ * Time: 12:55
+ */
+
+namespace Wikimedia\ForwardScript;
+
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * This is a special response for errors that can be handled well and should
+ * display an informative message to the user.
+ *
+ * It creates a 200 OK HTTP status code because otherwise the user would
+ * see the default Tool Labs error page.
+ *
+ * It uses text/plain content type to avoid the need for HTML escaping.
+ *
+ * @package Wikimedia\ForwardScript
+ */
+class ErrorResponse extends Response {
+	public function __construct( $content = '', $status = 200, $headers = array() ) {
+		$headers = array_merge(
+			[
+				// The normal status code will be overwritten by the Silex handler,
+				// see http://silex.sensiolabs.org/doc/usage.html#error-handlers
+				'X-Status-Code' => Response::HTTP_OK,
+				'Content-Type' => 'text/plain'
+			],
+			$headers
+		);
+		parent::__construct( $content, $status, $headers );
+	}
+
+
+}


### PR DESCRIPTION
Improve the error handling on Tool Labs: Log errors and send special header to avoid informative error messages being hidden by the reverse proxy.