### PR TITLE
Make some redirect script params optional

### DIFF
--- a/forward_script/README.md
+++ b/forward_script/README.md
@@ -17,10 +17,10 @@ Go to the `forward_script` directory and run the command
 
 You can then test it with URLs like
 
-`http://localhost:8080/redirect/Liste_der_Baudenkmäler_in_Abtswind/wlm-de-by/D-6-75-111-5/49.77168/10.37051`
+`http://localhost:8080/redirect/Liste_der_Baudenkmäler_in_Abtswind/wlm-de-by?id=D-6-75-111-5&lat=49.77168&lon=10.37051`
 
 The general structure of the URL is
 
-`http://localhost:8080/redirect/WIKIPEDIA_PAGENAME/COMMONS_CAMPAIGN_NAME/MONUMENT_ID/LATITUDE/LONGITUDE`
+`http://localhost:8080/redirect/WIKIPEDIA_PAGENAME/COMMONS_CAMPAIGN_NAME?id=MONUMENT_ID&lat=LATITUDE&lon=LONGITUDE`
 
 Only `WIKIPEDIA_PAGENAME` and `COMMONS_CAMPAIGN_NAME` are required parameters.

--- a/forward_script/app.php
+++ b/forward_script/app.php
@@ -58,8 +58,8 @@ $app->get( '/', function() {
 	return 'WLM redirect script';
 } );
 
-$app->get( '/redirect/{pageName}/{campaign}/{id}',
-	function ( Application $app, Request $request, $pageName, $campaign, $id ) {
+$app->get( '/redirect/{pageName}/{campaign}',
+	function ( Application $app, Request $request, $pageName, $campaign ) {
 		$campaignCacheId = "campaign_{$campaign}";
 		if ( $app['cache']->contains( $campaignCacheId ) ) {
 			$campaignIsValid = $app['cache']->fetch( $campaignCacheId );
@@ -73,6 +73,7 @@ $app->get( '/redirect/{pageName}/{campaign}/{id}',
 		if ( !$campaignIsValid ) {
 			throw new ApplicationException( 'Invalid campaign name.' );
 		}
+		$id = $request->get( 'id', '' );
 		$pageInfo = $app['pageinfo']->getInformation( $pageName, $id );
 		$coordinates = [
 			'lat' => $request->get( 'lat', '' ),
@@ -83,6 +84,6 @@ $app->get( '/redirect/{pageName}/{campaign}/{id}',
 		$redirectUrl .= 'campaign='.urlencode( $campaign );
 		$redirectUrl .= $queryBuilder->getQuery( $pageInfo, $pageName, $id, $coordinates );
 		return $app->redirect( $redirectUrl, Response::HTTP_MOVED_PERMANENTLY );
-	} )
-	->value( 'id', '' );
+	} );
+
 return $app;

--- a/forward_script/src/PageInformationCollector.php
+++ b/forward_script/src/PageInformationCollector.php
@@ -97,7 +97,7 @@ class PageInformationCollector {
 	 */
 	private function getInformationFromProcess( $pageContent, $monumentId ) {
 		$this->processCommand->setInput( $pageContent );
-		$monumentIdParam = ' ' . escapeshellarg( $monumentId );
+		$monumentIdParam = $monumentId ? ' -i ' . escapeshellarg( $monumentId ) : '';
 		$this->processCommand->setCommandLine(
 			$this->processCommand->getCommandLine() . $monumentIdParam
 		);

--- a/forward_script/tests/ApplicationTest.php
+++ b/forward_script/tests/ApplicationTest.php
@@ -53,7 +53,7 @@ class ApplicationTest extends WebTestCase {
 			(object)['category' => 'Category:Cultural heritage monuments in Abtswind']
 		);
 		$this->app['pageinfo']->method( 'getInformation' )->willReturn( $info );
-		$client->request( 'GET', '/redirect/Liste_der_Baudenkmäler_in_Abtswind/wlm-de-by/123' );
+		$client->request( 'GET', '/redirect/Liste_der_Baudenkmäler_in_Abtswind/wlm-de-by', ['id' => '123'] );
 		$this->assertTrue( $client->getResponse()->isRedirection(), 'Response is not a redirect' );
 		$expectedURL = 'https://commons.wikimedia.org/wiki/Special:UploadWizard?campaign=wlm-de-by' .
 			'&categories=Cultural+heritage+monuments+in+Abtswind' .

--- a/forward_script/tests/PageInformationCollectorTest.php
+++ b/forward_script/tests/PageInformationCollectorTest.php
@@ -122,7 +122,7 @@ class PageInformationCollectorTest extends PHPUnit_Framework_TestCase {
 			$this->equalTo( 'Page Text' )
 		);
 		$this->process->expects( $this->once() )->method( 'setCommandLine' )->with(
-			$this->equalTo( 'pythonscript \'D-6-75-111-7\'' )
+			$this->equalTo( 'pythonscript -i \'D-6-75-111-7\'' )
 		);
 		$this->process->method( 'isSuccessful' )->willReturn( true );
 		$this->process->method( 'getOutput' )->willReturn( '{"category":"test"}' );

--- a/update-bot/tests/test_pageinfo.py
+++ b/update-bot/tests/test_pageinfo.py
@@ -27,6 +27,13 @@ class TestPageinfo(unittest.TestCase):
         info = pageinfo.get_template_info(self.checker, self.mapper, text, "123")
         self.assertEqual(info, {"id_not_found": True, "category": "Weblink Category"})
 
+    def test_get_info_accepts_empty_id(self):
+        self.checker.is_allowed_template.return_value = False
+        self.mapper.get_commonscat_from_weblinks_template.return_value = "Weblink Category"
+        text = "{{Denkmalliste Sachsen Tabellenzeile|ID=1}}"
+        info = pageinfo.get_template_info(self.checker, self.mapper, text, "")
+        self.assertEqual(info, {"id_not_found": True, "category": "Weblink Category"})
+
     def test_get_info_returns_info(self):
         self.checker.is_allowed_template.return_value = True
         self.checker.get_id.return_value = "1"

--- a/update-bot/tests/test_pageinfo.py
+++ b/update-bot/tests/test_pageinfo.py
@@ -15,15 +15,17 @@ class TestPageinfo(unittest.TestCase):
     def test_get_info_returns_not_found_if_id_does_not_match(self):
         self.checker.is_allowed_template.return_value = True
         self.checker.get_id.return_value = "1"
+        self.mapper.get_commonscat_from_weblinks_template.return_value = "Weblink Category"
         text = "{{Denkmalliste Sachsen Tabellenzeile|ID=1}}"
         info = pageinfo.get_template_info(self.checker, self.mapper, text, "123")
-        self.assertEqual(info, {"id_not_found": True})
+        self.assertEqual(info, {"id_not_found": True, "category": "Weblink Category"})
 
     def test_get_info_returns_not_found_if_template_is_not_configured(self):
         self.checker.is_allowed_template.return_value = False
+        self.mapper.get_commonscat_from_weblinks_template.return_value = "Weblink Category"
         text = "{{Denkmalliste Sachsen Tabellenzeile|ID=1}}"
         info = pageinfo.get_template_info(self.checker, self.mapper, text, "123")
-        self.assertEqual(info, {"id_not_found": True})
+        self.assertEqual(info, {"id_not_found": True, "category": "Weblink Category"})
 
     def test_get_info_returns_info(self):
         self.checker.is_allowed_template.return_value = True

--- a/update-bot/wlmbots/pageinfo.py
+++ b/update-bot/wlmbots/pageinfo.py
@@ -11,6 +11,7 @@ import mwparserfromhell
 from wlmbots.lib.template_checker import TemplateChecker
 from wlmbots.lib.commonscat_mapper import CommonscatMapper
 
+
 def get_template_info(template_checker, commonscat_mapper, text, monument_id):
     id_count = 0
     info = {}
@@ -33,7 +34,9 @@ def get_template_info(template_checker, commonscat_mapper, text, monument_id):
         info["duplicate_ids"] = id_count > 1
     else:
         info["id_not_found"] = True
+        info["category"] = commonscat_mapper.get_commonscat_from_weblinks_template(text)
     return info
+
 
 def main():
     parser = argparse.ArgumentParser(description='Generate JSON info about monument data in wiki text.')

--- a/update-bot/wlmbots/pageinfo.py
+++ b/update-bot/wlmbots/pageinfo.py
@@ -12,7 +12,12 @@ from wlmbots.lib.template_checker import TemplateChecker
 from wlmbots.lib.commonscat_mapper import CommonscatMapper
 
 
-def get_template_info(template_checker, commonscat_mapper, text, monument_id):
+def get_template_info(template_checker, commonscat_mapper, text, monument_id=''):
+    if not monument_id:
+        return {
+            "id_not_found": True,
+            "category": commonscat_mapper.get_commonscat_from_weblinks_template(text)
+        }
     id_count = 0
     info = {}
     for template in mwparserfromhell.parse(text).filter_templates():
@@ -40,7 +45,8 @@ def get_template_info(template_checker, commonscat_mapper, text, monument_id):
 
 def main():
     parser = argparse.ArgumentParser(description='Generate JSON info about monument data in wiki text.')
-    parser.add_argument('monument_id', help='Unique ID of the monument. Validity will be checked.')
+    parser.add_argument('--monument_id', '-i', help='Unique ID of the monument. Validity will be checked.',
+                        default='', metavar='ID')
     parser.add_argument('infile', nargs='?', type=argparse.FileType('r'), default=sys.stdin)
     args = parser.parse_args()
     checker = TemplateChecker()


### PR DESCRIPTION
monument id, lat and long are now optional request parameters. This will make it
easier to leave them out in the template.

The redirect script without monument id is still useful - it will still add the most specific category  to the upload wizard parameters.