### PR TITLE
Improve script security

### DIFF
--- a/forward_script/app.php
+++ b/forward_script/app.php
@@ -48,11 +48,7 @@ $app->register( new Silex\Provider\MonologServiceProvider(), array(
 
 // Error handling
 $app->error( function ( ApplicationException $e, $code ) use ( $app ) {
-	return new ErrorResponse( $e->getMessage() );
-} );
-
-$app->error( function ( ProcessException $e, $code ) use ( $app ) {
-	return new ErrorResponse( $e->getMessage() );
+	return new ErrorResponse( $e->getMessage(), $code );
 } );
 
 // Routes

--- a/forward_script/src/ErrorResponse.php
+++ b/forward_script/src/ErrorResponse.php
@@ -12,15 +12,12 @@ use Symfony\Component\HttpFoundation\Response;
  * see the default Tool Labs error page.
  * See https://wikitech.wikimedia.org/wiki/Help:Tool_Labs/Web#Error_pages
  *
- * It uses text/plain content type to avoid the need for HTML escaping.
- *
  * @package Wikimedia\ForwardScript
  */
 class ErrorResponse extends Response {
 	public function __construct( $content = '', $status = 200, $headers = array() ) {
 		$headers = array_merge(
 			[
-				'Content-Type' => 'text/plain',
 				' X-Wikimedia-Debug' => '1'
 			],
 			$headers

--- a/forward_script/src/PageInformationCollector.php
+++ b/forward_script/src/PageInformationCollector.php
@@ -80,7 +80,7 @@ class PageInformationCollector {
 	 */
 	private function validatePage( array $page ) {
 		if ( isset( $page[ 'missing' ] ) ) {
-			throw new ApplicationException( "Page {$page['title']} not found." );
+			throw new ApplicationException( "Page was not found." );
 		}
 		if ( isset( $page[ 'invalid' ] ) ) {
 			throw new ApplicationException( 'Page name is invalid.' );


### PR DESCRIPTION
Removed a possible XSS attack surface (printing pagename) since setting
the content type of a response is not enough to mitigate XSS risk (see
http://security.stackexchange.com/questions/97241/does-a-content-type-text-plain-header-protect-against-xss-in-browsers

Don't show Python shell script errors to users.