### PR TITLE
Make ErrorResponse compatible with Tool Labs

### DIFF
--- a/forward_script/src/ErrorResponse.php
+++ b/forward_script/src/ErrorResponse.php
@@ -8,9 +8,13 @@ use Symfony\Component\HttpFoundation\Response;
  * This is a special response for errors that can be handled well and should
  * display an informative message to the user.
  *
- * It creates a 'X-Wikimedia-Debug' header because otherwise the user would
+ * It creates a '200 OK' response because otherwise the user would
  * see the default Tool Labs error page.
  * See https://wikitech.wikimedia.org/wiki/Help:Tool_Labs/Web#Error_pages
+ *
+ * The status code must be generated via the "X-Status-Code" header because the Silex error
+ * handler overrides the code by default.
+ * See http://silex.sensiolabs.org/doc/usage.html#error-handlers
  *
  * @package Wikimedia\ForwardScript
  */
@@ -18,7 +22,7 @@ class ErrorResponse extends Response {
 	public function __construct( $content = '', $status = 200, $headers = array() ) {
 		$headers = array_merge(
 			[
-				' X-Wikimedia-Debug' => '1'
+				'X-Status-Code' => 200
 			],
 			$headers
 		);


### PR DESCRIPTION
The previously used "X-Wikimedia-Debug" header didn't work because it
must be a *request* header. Now using a 200 OK status code instead to
avoid the proxy error page.