### PR TITLE
Improve monitoring messages

### DIFF
--- a/monitoring/TestFunctions.php
+++ b/monitoring/TestFunctions.php
@@ -5,31 +5,55 @@ require_once __DIR__ . '/functions.php';
 class TestFunctions extends PHPUnit_Framework_TestCase {
 
 	public function testResultHasErrorsIfReturnCodeIsNotARedirect() {
-		$this->assertTrue( resultHasErrors( 404, "", "" ) );
+		$expectedErrors = [true, "Wrong HTTP response code: 404"];
+		$this->assertEquals( $expectedErrors, resultHasErrors( 404, "", "" ) );
 	}
 
 	public function testResultHasErrorsIfResponseIsFalse() {
-		$this->assertTrue( resultHasErrors( 301, false, "" ) );
+		$expectedErrors = [true, "CURL encountered an error."];
+		$this->assertEquals( $expectedErrors, resultHasErrors( 301, false, "" ) );
 	}
 
 	public function testResultHasErrorsIfResponseDoesNotContainLocationPattern() {
-		$response = "X-Test: Foo\nLocation: http://example.com/foo/bar\n";
-		$this->assertTrue( resultHasErrors( 301, $response, "http://example.com/bar/foo" ) );
+		$response = "X-Test: Foo\r\nContent-Type: text/plain\r\n";
+		$expectedErrors = [true, "Location header is missing."];
+		$resultHasErrors = resultHasErrors( 301, $response, "http://example.com/bar/foo" );
+		$this->assertEquals( $expectedErrors, $resultHasErrors );
+	}
+
+	public function testResultHasErrorsIfResponseHasDifferentProtocolAndPath() {
+		$response = "X-Test: Foo\r\nLocation: http://example.com/bar/foo\r\n";
+		$resultHasErrors = resultHasErrors( 301, $response, "https://example.com/foo/bar" );
+		$this->assertTrue( $resultHasErrors[0] );
+		$this->assertContains( "scheme", $resultHasErrors[1] );
+		$this->assertContains( "path", $resultHasErrors[1] );
 	}
 
 	public function testResultHasErrorsIfResponseMatchesLocationPattern() {
-		$response = "X-Test: Foo\nLocation: http://example.com/foo/bar\n";
-		$this->assertFalse( resultHasErrors( 301, $response, "http://example.com/foo/bar" ) );
+		$response = "X-Test: Foo\r\nLocation: http://example.com/foo/bar\r\n";
+		$expectedErrors = [false, ""];
+		$resultHasErrors = resultHasErrors( 301, $response, "http://example.com/foo/bar" );
+		$this->assertEquals( $expectedErrors, $resultHasErrors );
 	}
 
 	public function testResultHasErrorsIfResponseMatchesLocationPatternWithDifferentParamOrder() {
-		$response = "X-Test: Foo\nLocation: http://example.com/?foo=1&bar=2\n";
-		$this->assertFalse( resultHasErrors( 301, $response, "http://example.com/?bar=2&foo=1" ) );
+		$response = "X-Test: Foo\r\nLocation: http://example.com/?foo=1&bar=2\r\n";
+		$expectedErrors = [false, ""];
+		$resultHasErrors = resultHasErrors( 301, $response, "http://example.com/?bar=2&foo=1" );
+		$this->assertEquals( $expectedErrors, $resultHasErrors );
 	}
 
-	public function testResultHasErrorsHandlesFieldArrayParam() {
-		$response = "X-Test: Foo\nLocation: http://example.com/?fields[]=1\n";
-		$this->assertFalse( resultHasErrors( 301, $response, "http://example.com/?fields[]=1" ) );
-		$this->assertTrue( resultHasErrors( 301, $response, "http://example.com/?fields[]=7" ) );
+	public function testResultHasErrorsHandlesFieldArrayParamWithCorrectId() {
+		$response = "X-Test: Foo\r\nLocation: http://example.com/?fields[]=1\r\n";
+		$expectedErrors = [false, ""];
+		$resultHasErrors = resultHasErrors( 301, $response, "http://example.com/?fields[]=1" );
+		$this->assertEquals( $expectedErrors, $resultHasErrors );
+	}
+
+	public function testResultHasErrorsHandlesFieldArrayParamWithWrongId() {
+		$response = "X-Test: Foo\r\nLocation: http://example.com/?fields[]=1\r\n";
+		$resultHasErrors = resultHasErrors( 301, $response, "http://example.com/?fields[]=7" );
+		$this->assertTrue( $resultHasErrors[0] );
+		$this->assertContains( "field", $resultHasErrors[1] );
 	}
 }

--- a/monitoring/config.php
+++ b/monitoring/config.php
@@ -6,7 +6,7 @@ $subjectPrefix = '[WLM-Monitor]';
 
 // Forward script settings
 $checkURL = 'https://tools.wmflabs.org/wlm-de-utils/redirect/Benutzer%3AGabriel+Birke+%28WMDE%29%2FDemo+Liste+Baudenkmale+Bad+Wiessee/wlm-de-by?id=D-1-82-111-30&lat=11.70699&lon=47.73638';
-$expectedLocation = 'https://commons.wikimedia.org/wiki/Special:UploadWizard';
+$expectedLocation = 'https://commons.wikimedia.org/wiki/Special:UploadWizard?campaign=wlm-de-by&lat=11.70699&lon=47.73638&categories=Cultural+heritage+monuments+in+Bad+Wiessee%7CUploaded+with+UploadWizard+via+delists&objref=de%7CBenutzer%3AGabriel_Birke_%28WMDE%29%2FDemo_Liste_Baudenkmale_Bad_Wiessee%7CD-1-82-111-30&fields%5B%5D=D-1-82-111-30&updateList=1';
 
 // Bot check settings
 $checkPatterns = [

--- a/monitoring/functions.php
+++ b/monitoring/functions.php
@@ -53,12 +53,12 @@ function resultHasErrors( $httpCode, $response, $expectedLocation ) {
 	list( $responseLocationParsed, $responseQuery ) = getUrlElementsAndQueryArray( $matches[1] );
 	$urlDifference = array_diff( $responseLocationParsed, $expectedLocationParsed );
 	if ( $urlDifference != [] ) {
-		$errorReason = "Unexpected URL part difference: ".var_export( $urlDifference, true );
-		return [true, $errorReason ];
+		$errorReason = "Unexpected URL part difference: " . var_export( $urlDifference, true );
+		return [true, $errorReason];
 	}
 	$queryDifference = array_diff( $responseQuery, $expectedQuery );
 	if ( $queryDifference != [] ) {
-		$errorReason = "Unexpected query string difference: ".var_export( $queryDifference, true );
+		$errorReason = "Unexpected query string difference: " . var_export( $queryDifference, true );
 		return [true, $errorReason];
 	}
 	return [false, ""];

--- a/monitoring/functions.php
+++ b/monitoring/functions.php
@@ -41,20 +41,27 @@ function mustNotify( $filename, $notificationInterval ) {
  */
 function resultHasErrors( $httpCode, $response, $expectedLocation ) {
 	if ( !in_array( $httpCode, [301, 302] ) ){
-		return true;
+		return [true, "Wrong HTTP response code: $httpCode"];
 	}
 	if ( $response === false ) {
-		return true;
+		return [true, "CURL encountered an error."];
 	}
-	if ( !preg_match( '/Location:\s*([^\n]+)/i', $response, $matches ) ) {
-		return true;
+	if ( !preg_match( '/Location:\s*([^\r\n]+)/i', $response, $matches ) ) {
+		return [true, "Location header is missing."];
 	}
 	list( $expectedLocationParsed, $expectedQuery ) = getUrlElementsAndQueryArray( $expectedLocation );
 	list( $responseLocationParsed, $responseQuery ) = getUrlElementsAndQueryArray( $matches[1] );
-	if ( array_diff( $expectedLocationParsed, $responseLocationParsed ) != [] ) {
-		return true;
+	$urlDifference = array_diff( $responseLocationParsed, $expectedLocationParsed );
+	if ( $urlDifference != [] ) {
+		$errorReason = "Unexpected URL part difference: ".var_export( $urlDifference, true );
+		return [true, $errorReason ];
 	}
-	return array_diff( $expectedQuery, $responseQuery ) != [];
+	$queryDifference = array_diff( $responseQuery, $expectedQuery );
+	if ( $queryDifference != [] ) {
+		$errorReason = "Unexpected query string difference: ".var_export( $queryDifference, true );
+		return [true, $errorReason];
+	}
+	return [false, ""];
 }
 
 function getUrlElementsAndQueryArray( $url ) {

--- a/monitoring/monitor_response.php
+++ b/monitoring/monitor_response.php
@@ -17,9 +17,14 @@ curl_setopt( $ch, CURLOPT_USERAGENT, 'WLM monitoring script' ); // Tool labs ref
 $response = curl_exec( $ch );
 
 $httpCode = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
-if ( resultHasErrors( $httpCode, $response, $expectedLocation ) ) {
-	$errorMessage = "Got the following result back:\n\n$response";
-	$errorMessage .= 'CURL error: ' . curl_error( $ch );
+list( $resultHasError, $errorReason ) = resultHasErrors( $httpCode, $response, $expectedLocation );
+if ( $resultHasError ) {
+	$errorMessage = "Error: $errorReason\n\n";
+	$errorMessage .= "Got the following result back:\n\n$response";
+	$curlError = curl_error( $ch );
+	if ( $curlError ) {
+		$errorMessage .= "\nCURL error: $curlError\n";
+	}
 	notifyConditionally(
 		$notifyMail,
 		"$subjectPrefix Forward script check failed",


### PR DESCRIPTION
Add an error reason to each possible check to help with finding the error.
    
Corrected the regular expression that finds the location string: It was eating the \r from the \r\n header separator.
    
Update unit tests to reflect the correct header delimiter.

Update the expected URL.